### PR TITLE
Add pprof binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,12 @@
-FROM golang:1.14.4 as gobuilder
-
-RUN go get github.com/google/pprof
-
 FROM quay.io/openshift/origin-must-gather:4.6 as builder
 
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 
 RUN microdnf -y install rsync tar gzip graphviz
 
-COPY --from=gobuilder /go/bin/pprof /usr/bin/pprof
 COPY --from=builder /usr/bin/oc /usr/bin/oc
+COPY pprof-master /usr/bin/pprof
 COPY collection-scripts/* /usr/bin/
 
 ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
This is an ugly hack to allow building downstream images. With the binary directly in the repository, everything is self contained, so Cachito will download the pprof binary and we will be able to use it. The downside is that putting binaries is a wrong practice, so we'll need to revert this hack. This is why I limit this change to the release-v2.0.0 branch.