### PR TITLE
Revert "Add pprof binary"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
+FROM golang:1.14.4 as gobuilder
+
+RUN go get github.com/google/pprof
+
 FROM quay.io/openshift/origin-must-gather:4.6 as builder
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8-minimal:latest
 RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 
 RUN microdnf -y install rsync tar gzip graphviz
 
+COPY --from=gobuilder /go/bin/pprof /usr/bin/pprof
 COPY --from=builder /usr/bin/oc /usr/bin/oc
-COPY pprof-master /usr/bin/pprof
 COPY collection-scripts/* /usr/bin/
 
 ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
Reverts konveyor/forklift-must-gather#2.
Downstream we now have an intermediate image to build pprof, so that it can be added to the must-gather image.