### PR TITLE
Add targeted gathering for NS, PLAN and VM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM golang:1.14.4 as gobuilder
 
 RUN go get github.com/google/pprof
 
-FROM quay.io/openshift/origin-must-gather:4.6 as builder
+FROM quay.io/openshift/origin-must-gather:4.7 as builder
 
 FROM registry.access.redhat.com/ubi8-minimal:latest
 RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 
-RUN microdnf -y install rsync tar gzip graphviz
+RUN microdnf -y install rsync tar gzip graphviz jq
 
 COPY --from=gobuilder /go/bin/pprof /usr/bin/pprof
 COPY --from=builder /usr/bin/oc /usr/bin/oc

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `must-gather` is a tool built on top of [OpenShift must-gather](https://github.com/openshift/must-gather)
 that expands its capabilities to gather Forklift specific resources
 
-### Usage
+## Usage
 ```sh
 oc adm must-gather --image=quay.io/konveyor/forklift-must-gather:latest
 ```
@@ -13,9 +13,19 @@ The command above will create a local directory with a dump of the Forklift stat
 You will get a dump of Forklift-related:
 - logs
 - CRs
-- metrics
+- metrics (optional)
 
-#### Preview metrics on local Prometheus server
+### Targeted gathering
+
+To reduce amount of data and time consumed by must-gather, there is a "targeted" version which allows dump only selected resources.
+
+It is possible specify namespace (NS), plan (PLAN) or virtual machine ID (VM).
+
+```sh
+oc adm must-gather --image=quay.io/konveyor/forklift-must-gather:latest -- NS=ns1 PLAN=plan1 VM=vm-3345 /usr/bin/targeted
+```
+
+### Preview metrics on local Prometheus server
 
 Get Prometheus metrics data directory dump (last day, might take a while):
 ```sh
@@ -28,28 +38,7 @@ make prometheus-run # and prometheus-cleanup when you're done
 ```
 The latest Prometheus data file (prom_data.tar.gz) in current directory/subdirectories is searched by default. Could be specified in ```PROMETHEUS_DUMP_PATH``` environment variable.
 
-#### Analyze forklift-controller memory profile
-
-In the must-gather archive, find the `memory-profiles` directory:
-
-```sh
-cd memory-profiles/openshift-migration
-```
-
-Here, you will find memory profile of forklift-controller in two formats - a binary and a png file. The binary file `pprof_raw_payload` contains the full heap represention of forklift-controller, while the PNG file is a simple graphical representation of memory allocation.
-
-To analyze the raw binary heap data on your machine, use `go tool pprof`:
-
-```sh
-go tool pprof pprof_raw_payload
-```
-
-This will open an interactive `pprof` terminal. Type `help` in the terminal for more information.
-
-The instructions to set up pprof are available here: [https://github.com/google/pprof](https://github.com/google/pprof) 
-
-
-### Development
+## Development
 You can build the image locally using the Dockerfile included.
 
 A `Makefile` is also provided. To use it, you must pass a repository via the command-line using the variable `IMAGE_NAME`.

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -1,22 +1,23 @@
 #!/bin/bash
 
 unset KUBECONFIG
+
+# Optional targeted parameters
+if [ ! -z "${NS}" ]; then
+  echo "Running targeted gathering for namespace ${NS}"
+  export userns="${NS}"
+fi
+
+# Explore where Forklift is installed
 for localns in $(/usr/bin/oc get forkliftcontrollers.forklift.konveyor.io --all-namespaces --no-headers | awk '{print $1}'); do
 
   # Collect the Forklift and Kubevirt related CRs
   echo "Gathering Forklift and Kubevirt related CRs for namespaces [${localns}]"
-  /usr/bin/gather_crs ${localns} &
+  /usr/bin/gather_crs ${localns} ${userns} &
 
   # Collect the logs
   echo "Gathering logs for namespaces [${localns}]"
   /usr/bin/gather_logs ${localns} &
-
-  # Collect metrics from Prometheus
-  echo "Gathering prometheus metrics"
-  /usr/bin/gather_metrics &
-
-  # Collect memory profile data
-  /usr/bin/gather_pprof ${localns} &
 
   # Waits for gather_crs, gather_logs, gather_metrics running in background
   echo "Waiting for background gather tasks to finish"

--- a/collection-scripts/gather_crs
+++ b/collection-scripts/gather_crs
@@ -2,9 +2,8 @@
 source pwait
 max_parallelism=10
 
-# Forklift namespace passed in from main gather
-backend_namespace=$1
-user_namespace=$2
+# Namespaces passed in from main gather
+namespaces=$1
 
 # Resource list
 resources=()
@@ -19,21 +18,9 @@ for component in forklift kubevirt; do
 
   # we use nested loops to nicely output objects partitioned per namespace, kind
   for resource in ${resources[@]}; do
-    echo "Collecting CR ${resource}"
-
-    if [ -z "${user_namespace}" ]; then
-      objects=$(/usr/bin/oc get ${resource} --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null)
-    else
-      migtoolkit_cnv_objects=$(/usr/bin/oc get ${resource} -n ${backend_namespace} -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null)
-      vm_related_objects=$(/usr/bin/oc get ${resource} -n ${user_namespace} -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null)
-      objects="$(echo $migtoolkit_cnv_objects; echo $vm_related_objects)"
-    fi
-
-    echo "$objects" | \
+    echo "Collecting ${resource}"
+    /usr/bin/oc get ${resource} --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | \
     while read ocresource; do
-      if [ -z "${ocresource}" ]; then
-        continue
-      fi
       ocobject=$(echo $ocresource | awk '{print $1}')
       ocproject=$(echo $ocresource | awk '{print $2}')
       if [ -z "${ocproject}" ]|[ "${ocproject}" == "<none>" ]; then

--- a/collection-scripts/gather_crs
+++ b/collection-scripts/gather_crs
@@ -2,8 +2,9 @@
 source pwait
 max_parallelism=10
 
-# Namespaces passed in from main gather
-namespaces=$1
+# Forklift namespace passed in from main gather
+backend_namespace=$1
+user_namespace=$2
 
 # Resource list
 resources=()
@@ -18,9 +19,21 @@ for component in forklift kubevirt; do
 
   # we use nested loops to nicely output objects partitioned per namespace, kind
   for resource in ${resources[@]}; do
-    echo "Collecting ${resource}"
-    /usr/bin/oc get ${resource} --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | \
+    echo "Collecting CR ${resource}"
+
+    if [ -z "${user_namespace}" ]; then
+      objects=$(/usr/bin/oc get ${resource} --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null)
+    else
+      migtoolkit_cnv_objects=$(/usr/bin/oc get ${resource} -n ${backend_namespace} -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null)
+      vm_related_objects=$(/usr/bin/oc get ${resource} -n ${user_namespace} -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null)
+      objects="$(echo $migtoolkit_cnv_objects; echo $vm_related_objects)"
+    fi
+
+    echo "$objects" | \
     while read ocresource; do
+      if [ -z "${ocresource}" ]; then
+        continue
+      fi
       ocobject=$(echo $ocresource | awk '{print $1}')
       ocproject=$(echo $ocresource | awk '{print $2}')
       if [ -z "${ocproject}" ]|[ "${ocproject}" == "<none>" ]; then

--- a/collection-scripts/targeted
+++ b/collection-scripts/targeted
@@ -1,4 +1,11 @@
 #!/bin/bash
+#
+# THIS SCRIPT PROVIDES TARGETED GATHERING BASED ON NS, PLAN AND VM NAME
+#
+# NOTICE: THIS FILE IS NOT INCLUDED IN THE DEFAULT GATHER SCRIPT
+#
+# Can be executed by: oc adm must-gather --image quay.io/konveyor/forklift-must-gather:latest -- NS=foo PLAN=bar VM=baz /usr/bin/targeted
+#
 
 unset KUBECONFIG
 
@@ -6,16 +13,12 @@ unset KUBECONFIG
 for localns in $(/usr/bin/oc get forkliftcontrollers.forklift.konveyor.io --all-namespaces --no-headers | awk '{print $1}'); do
 
   # Collect the Forklift and Kubevirt related CRs
-  echo "Gathering Forklift and Kubevirt related CRs for namespaces [${localns}]"
-  /usr/bin/gather_crs ${localns} &
+  echo "Targeted gathering for Forklift in namespaces [${localns}]"
+  /usr/bin/targeted_crs ${localns} || exit 1
 
   # Collect the logs
   echo "Gathering logs for namespaces [${localns}]"
-  /usr/bin/gather_logs ${localns} &
-
-  # Waits for gather_crs, gather_logs, gather_metrics running in background
-  echo "Waiting for background gather tasks to finish"
-  wait
+  /usr/bin/targeted_logs ${localns}
 done
 
 # Tar all must-gather artifacts for faster transmission 
@@ -27,7 +30,6 @@ rm -rf /must-gather/*
 mv ${archive_path}/must-gather.tar.gz /must-gather/
 rmdir ${archive_path}
 echo "Created /must-gather/must-gather.tar.gz"
-
 
 echo "Waiting for copy phase..."
 exit 0

--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -1,0 +1,136 @@
+#!/bin/bash
+#
+# THIS SCRIPT PROVIDES TARGETED GATHERING BASED ON NS, PLAN AND VM NAME
+#
+# NOTICE: THIS FILE IS NOT INCLUDED IN THE DEFAULT GATHER SCRIPT
+#
+# Can be executed by: oc adm must-gather --image quay.io/konveyor/forklift-must-gather:latest -- NS=foo PLAN=bar VM=baz MIGRATION_NS=openshift-migration /usr/bin/targeted
+#
+
+unset KUBECONFIG
+
+object_collection_path="/must-gather"
+mkdir -p ${object_collection_path}
+
+#source pwait
+#max_parallelism=10
+
+# Set Forklift namespace
+MIGRATION_NS=$1
+
+# Resource list
+dv_resources=()
+plan_resources=()
+vm_resources=()
+vmimport_resources=()
+target_ns=""
+log_filter_query=""
+
+# Parse provided parameters
+if [ -z $NS ] && [ -z $PLAN ] && [ -z $VM ]; then
+  echo "ERROR: Missing targeted gathering parameters. Use NS, PLAN and/or VM env variables."
+  exit 1
+fi
+
+if [ ! -z $NS ]; then
+  echo "Targeted gathering for Namespace: $NS"
+  # Populate NS resources only if PLAN and VM parameters were not provided
+  if [[ -z $PLAN && -z $VM ]]; then
+    plans_data=$(/usr/bin/oc get plans -n $MIGRATION_NS -o json)
+    plan_resources+=($(echo $plans_data | jq ".items[]|select(.spec.targetNamespace==\"$NS\")|.metadata.name" | sed 's/"//g'))
+    vm_resources+=($(echo $plans_data | jq ".items[]|select(.spec.targetNamespace==\"$NS\")|.spec.vms[] .id" | sed 's/"//g'))
+  fi
+  target_ns=$NS
+fi
+
+if [ ! -z $PLAN ]; then
+  echo "Targeted gathering for Plan: $PLAN"
+  plan_data=$(/usr/bin/oc get plan $PLAN -n $MIGRATION_NS -o json)
+  if [ ! -z "${plan_data}" ]; then
+    plan_resources+=("$PLAN")
+    vm_resources+=($(echo $plan_data | jq '.spec.vms[] .id' | sed 's/"//g'))
+    target_ns=$(echo $plan_data | jq '.spec.targetNamespace' | sed 's/"//g')
+  fi
+fi
+
+if [ ! -z $VM ]; then
+  # VM ID (e.g. from migration plan) needs to be provided, since kubevirt VM name is not clearly translate-able to its migration id
+  echo "Targeted gathering for VM ID: $VM"
+  vm_resources+=("$VM")
+  if [ -z "${target_ns}" ]; then
+    # Try to identify a namespace for provided VM name
+    vm_list=$(oc get virtualmachines -A | grep ${VM})
+    if [ $(echo "$vm_list" | wc -l) == "1" ]; then
+      target_ns=$(echo "$vm_list" | cut -f1 -d" ")
+    else
+      echo "ERROR: Mutiple VMs found for provided VM name. Use NS env variable together with VM env variable to specify the right one using its ID."
+      echo "${vm_list}"
+      exit 1
+    fi
+  fi
+fi
+
+# Start gathering of resources based on its type
+
+function dump_resource {
+  resource=$1
+  ocobject=$2
+  ocproject=$3
+  echo "Dumping ${resource}: ${ocobject} from ${ocproject}"
+  if [ -z "${ocproject}" ]|[ "${ocproject}" == "<none>" ]; then
+    object_collection_path=/must-gather/cluster-scoped-resources/${resource}
+    mkdir -p ${object_collection_path}
+    /usr/bin/oc get ${resource} -o yaml ${ocobject} &> ${object_collection_path}/${ocobject}.yaml
+  else
+    object_collection_path=/must-gather/namespaces/${ocproject}/crs/${resource}
+    mkdir -p ${object_collection_path}
+    /usr/bin/oc get ${resource} -n ${ocproject} -o yaml ${ocobject} &> ${object_collection_path}/${ocobject}.yaml
+  fi
+}
+
+if [ ! -z "${plan_resources}" ]; then
+    echo "Gathering plans.."
+    for plan_id in ${plan_resources[@]}; do
+      log_filter_query="$log_filter_query|openshift-migration\/$plan_id"
+      dump_resource "plan" $plan_id $MIGRATION_NS
+    done
+fi
+
+if [ ! -z "${vm_resources}" ]; then
+    echo "Gathering virtualmachines.."
+    for vm_id in ${vm_resources[@]}; do
+      # Parse VM and VMImport for related resources
+      vmimports_data=$(/usr/bin/oc get virtualmachineimport --selector vmID=${vm_id} -n ${target_ns} -o json)
+      target_vm_name=$(echo $vmimports_data | jq '.items[]|.spec.targetVmName' | sed 's/"//g')
+      vmimport_resources+=$(echo $vmimports_data | jq '.items[]|.metadata.name' | sed 's/"//g')
+
+      vm_data=$(/usr/bin/oc get virtualmachine ${target_vm_name} -n ${target_ns} -o json)
+      dv_resources+=$(echo $vm_data | jq '.spec.template.spec.volumes[] .dataVolume.name' | sed 's/"//g')
+    
+      log_filter_query="$log_filter_query|$vm_id"
+      dump_resource "virtualmachine" $target_vm_name $target_ns
+    done
+fi
+
+if [ ! -z "${vmimport_resources}" ]; then
+    echo "Gathering virtualmachineimports.."
+    for vmi_id in ${vmimport_resources[@]}; do
+        dump_resource "virtualmachineimport" $vmi_id $target_ns
+    done
+fi
+
+if [ ! -z "${dv_resources}" ]; then
+    echo "Gathering datavolumes.."
+    for dv_id in ${dv_resources[@]}; do
+        dump_resource "datavolume" $dv_id $target_ns
+    done
+fi
+
+# Show message in case of empty result
+if [ -z $plan_resources ] && [ -z $vm_resources ] && [ -z $vmimport_resources ] && [ -z $dv_resources ]; then
+  echo "ERROR: No resources matching the criteria were found. Try adjust NS, PLAN or VM env variables."
+  exit 1
+fi
+
+# Store condition for logs filtering
+echo "${log_filter_query:1}" > /tmp/targeted_logs_grep_query

--- a/collection-scripts/targeted_logs
+++ b/collection-scripts/targeted_logs
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# THIS SCRIPT PROVIDES TARGETED GATHERING BASED ON NS, PLAN AND VM NAME
+#
+# NOTICE: THIS FILE IS NOT INCLUDED IN THE DEFAULT GATHER SCRIPT
+#
+# Can be executed by: oc adm must-gather --image quay.io/konveyor/forklift-must-gather:latest -- NS=foo PLAN=bar VM=baz MIGRATION_NS=openshift-migration /usr/bin/targeted
+#
+
+unset KUBECONFIG
+source pwait
+max_parallelism=10
+
+# Namespaces passed in from main gather
+namespaces=$1
+targeted_query="$(cat /tmp/targeted_logs_grep_query)"
+
+# Collect all Pod logs from namespaces where Forklift is installed
+for ns in ${namespaces[@]}; do
+  for pod in $(/usr/bin/oc get pods --no-headers --namespace $ns | awk '{print $1}'); do
+    object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
+    mkdir -p ${object_collection_path}
+    echo "[ns=${ns}][pod=${pod}] Collecting Pod logs..."
+    /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} | grep -E $targeted_query &> "${object_collection_path}/current.log" &
+    pwait $max_parallelism
+  done
+done
+
+
+# Collect related CNV components logs: CDI and vm-import
+ns=openshift-cnv
+for component in cdi vm-import; do
+  for pod in $(/usr/bin/oc get pods --no-headers --namespace $ns | grep $component | awk '{print $1}'); do
+    object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
+    mkdir -p ${object_collection_path}
+    echo "[ns=${ns}][pod=${pod}] Collecting Pod logs..."
+    /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} | grep -E $targeted_query &> "${object_collection_path}/current.log" &
+    pwait $max_parallelism
+  done
+done
+
+wait


### PR DESCRIPTION
In order to reduce amount of data&time must-gather takes, it was added an option to gather only given namespace, plan or VM resources.

This is related to https://github.com/konveyor/forklift-must-gather/issues/3 

## Example usage

Example command for targeted gathering with all possible arguments:

```
$ oc adm must-gather --image=quay.io/maufart/forklift-must-gather:targeted1 -- NS=ns1 PLAN=plan1 VM=vm-3345 /usr/bin/targeted
```

Testing image: _quay.io/maufart/forklift-must-gather:targeted1_

Demo video:
[![preview video](https://img.youtube.com/vi/c2FwJPbhnR4/0.jpg)](https://www.youtube.com/watch?v=c2FwJPbhnR4)

Possible enhancements/TODOs:
paralelize CRs gathering if needed
possible vm name/id translation
