### PR TITLE
Update Makefile allow set local container engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMAGE_REGISTRY ?= quay.io
 IMAGE_TAG ?= latest
 IMAGE_NAME ?= konveyor/forklift-must-gather
-CONTAINER_ENGINE ?= docker
+CONTAINER_ENGINE ?= $(shell if [ -e /usr/bin/podman ]; then echo "/usr/bin/podman"; else echo "docker"; fi)
 
 PROMETHEUS_LOCAL_DATA_DIR ?= /tmp/mig-prometheus-data-dump
 # Search for prom_data.tar.gz archive in must-gather output in currect directory by default


### PR DESCRIPTION
Adding CONTAINER_ENGINE environment variable to Makefile which is used to control if docker or podman or something else should be used for building images and running local containers.

If empty, it looks for podman by default and fallbacks to docker if /usr/bin/podman was not available.