### PR TITLE
Fix Targeted error for non-existing NS

### DIFF
--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -34,6 +34,11 @@ fi
 
 if [ ! -z $NS ]; then
   echo "Targeted gathering for Namespace: $NS"
+  # Check if the NS exists (so it could used to get Plans/VMs later)
+  if [ $(oc get namespace "$NS" 2>&1 | grep "not found" | wc -l) == "1" ]; then
+    echo "ERROR: Specified NS doesn't exist, targeted gathering cannot continue. Set NS to an existing namespace."
+    exit 1
+  fi
   # Populate NS resources only if PLAN and VM parameters were not provided
   if [[ -z $PLAN && -z $VM ]]; then
     plans_data=$(/usr/bin/oc get plans -n $MIGRATION_NS -o json)


### PR DESCRIPTION
Adding check to targeted gathering if the provided NS exist. This should
avoid errors caused by not existing NS when getting Plans/VMs in later
parts of the targeted gathering script.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1996360