### PR TITLE
Update VM parsing to use Plan instead of VMImport

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You will get a dump of Forklift-related:
 
 ### Targeted gathering
 
-To reduce amount of data and time consumed by must-gather, there is a "targeted" version which allows dump only selected resources. It is possible specify namespace (NS), plan (PLAN) or virtual machine ID (VM). The archive will only contain CRs relevant for selected resources and filtered set of log files.
+To reduce amount of data and time consumed by must-gather, there is a "targeted" version which allows dump only selected resources. It is possible specify namespace (NS), plan (PLAN) or virtual machine name (VM). The archive will only contain CRs relevant for selected resources and filtered set of log files.
 
 Following targeted gathering parameters are supported:
 
@@ -33,7 +33,7 @@ oc adm must-gather --image=quay.io/konveyor/forklift-must-gather:latest -- PLAN=
 ```
 
 
-VM (its ID from the Plan) together with namespace where the VM belongs to
+VM name together with namespace where the VM belongs to
 
 ```sh
 oc adm must-gather --image=quay.io/konveyor/forklift-must-gather:latest -- NS=ns1 VM=vm-3345 /usr/bin/targeted

--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -22,7 +22,6 @@ MIGRATION_NS=$1
 dv_resources=()
 plan_resources=()
 vm_resources=()
-vmimport_resources=()
 target_ns=""
 log_filter_query=""
 
@@ -42,8 +41,8 @@ if [ ! -z $NS ]; then
   # Populate NS resources only if PLAN and VM parameters were not provided
   if [[ -z $PLAN && -z $VM ]]; then
     plans_data=$(/usr/bin/oc get plans -n $MIGRATION_NS -o json)
-    plan_resources+=($(echo $plans_data | jq ".items[]|select(.spec.targetNamespace==\"$NS\")|.metadata.name" | sed 's/"//g'))
-    vm_resources+=($(echo $plans_data | jq ".items[]|select(.spec.targetNamespace==\"$NS\")|.spec.vms[] .id" | sed 's/"//g'))
+    plan_resources+=($(echo $plans_data | jq -r ".items[]|select(.spec.targetNamespace==\"$NS\")|.metadata.name"))
+    vm_resources+=($(echo $plans_data | jq -r ".items[]|select(.spec.targetNamespace==\"$NS\")|.status.migration.vms[] .name"))
   fi
   target_ns=$NS
 fi
@@ -53,14 +52,14 @@ if [ ! -z $PLAN ]; then
   plan_data=$(/usr/bin/oc get plan $PLAN -n $MIGRATION_NS -o json)
   if [ ! -z "${plan_data}" ]; then
     plan_resources+=("$PLAN")
-    vm_resources+=($(echo $plan_data | jq '.spec.vms[] .id' | sed 's/"//g'))
-    target_ns=$(echo $plan_data | jq '.spec.targetNamespace' | sed 's/"//g')
+    vm_resources+=($(echo $plan_data | jq -r '.status.migration.vms[] .name'))
+    target_ns=$(echo $plan_data | jq -r '.spec.targetNamespace')
   fi
 fi
 
 if [ ! -z $VM ]; then
   # VM ID (e.g. from migration plan) needs to be provided, since kubevirt VM name is not clearly translate-able to its migration id
-  echo "Targeted gathering for VM ID: $VM"
+  echo "Targeted gathering for VM: $VM"
   vm_resources+=("$VM")
   if [ -z "${target_ns}" ]; then
     # Try to identify a namespace for provided VM name
@@ -103,24 +102,15 @@ fi
 
 if [ ! -z "${vm_resources}" ]; then
     echo "Gathering virtualmachines.."
-    for vm_id in ${vm_resources[@]}; do
-      # Parse VM and VMImport for related resources
-      vmimports_data=$(/usr/bin/oc get virtualmachineimport --selector vmID=${vm_id} -n ${target_ns} -o json)
-      target_vm_name=$(echo $vmimports_data | jq '.items[]|.spec.targetVmName' | sed 's/"//g')
-      vmimport_resources+=$(echo $vmimports_data | jq '.items[]|.metadata.name' | sed 's/"//g')
-
+    for target_vm_name in ${vm_resources[@]}; do
+      # Parse VM for related resources
       vm_data=$(/usr/bin/oc get virtualmachine ${target_vm_name} -n ${target_ns} -o json)
-      dv_resources+=$(echo $vm_data | jq '.spec.template.spec.volumes[] .dataVolume.name' | sed 's/"//g')
+      for dv_name in $(echo $vm_data | jq -r '.spec.template.spec.volumes[] .dataVolume.name'); do
+        dv_resources+=("$dv_name")
+      done
     
-      log_filter_query="$log_filter_query|$vm_id"
+      log_filter_query="$log_filter_query|$target_vm_name"
       dump_resource "virtualmachine" $target_vm_name $target_ns
-    done
-fi
-
-if [ ! -z "${vmimport_resources}" ]; then
-    echo "Gathering virtualmachineimports.."
-    for vmi_id in ${vmimport_resources[@]}; do
-        dump_resource "virtualmachineimport" $vmi_id $target_ns
     done
 fi
 
@@ -132,10 +122,11 @@ if [ ! -z "${dv_resources}" ]; then
 fi
 
 # Show message in case of empty result
-if [ -z $plan_resources ] && [ -z $vm_resources ] && [ -z $vmimport_resources ] && [ -z $dv_resources ]; then
+if [ -z $plan_resources ] && [ -z $vm_resources ] && [ -z $dv_resources ]; then
   echo "ERROR: No resources matching the criteria were found. Try adjust NS, PLAN or VM env variables."
   exit 1
 fi
 
 # Store condition for logs filtering
-echo "${log_filter_query:1}" > /tmp/targeted_logs_grep_query
+echo "Condition for targeted logs filtering:"
+echo "${log_filter_query:1}" | tee /tmp/targeted_logs_grep_query


### PR DESCRIPTION
This PR finalizes must-gather changes related to Forklift 2.2 replacement of VMIO functions.

Adapting the gathering code to correctly parsing VM-related objects (VM itself and DVs). As a side-effect, VM name (instead of within-plan ID) is used be passed in parameters (as Forklift UI already does).

Fixes BZs:
https://bugzilla.redhat.com/show_bug.cgi?id=2019307
https://bugzilla.redhat.com/show_bug.cgi?id=1995197
https://bugzilla.redhat.com/show_bug.cgi?id=2020014