### PR TITLE
Include migrations CR in targeted gathering

### DIFF
--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -93,10 +93,11 @@ function dump_resource {
 }
 
 if [ ! -z "${plan_resources}" ]; then
-    echo "Gathering plans.."
+    echo "Gathering plans and their migrations.."
     for plan_id in ${plan_resources[@]}; do
       log_filter_query="$log_filter_query|openshift-migration\/$plan_id"
       dump_resource "plan" $plan_id $MIGRATION_NS
+      dump_resource "migration" $(echo $plan_id | sed "s/plan$/migration/") $MIGRATION_NS
     done
 fi
 


### PR DESCRIPTION
A Plan CR should be enough for most of debugging purposes, however adding also Migration CR to provide really all available data in the targeted gathering archive.