### PR TITLE
Upgrade oc to v4.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-must-gather:4.7 as builder
+FROM quay.io/openshift/origin-must-gather:4.9 as builder
 
 FROM registry.access.redhat.com/ubi8-minimal:latest
 RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo


### PR DESCRIPTION
Updating oc (OpenShift client tool) to v4.9 to match to the current OpenShift version with MTV 2.2.