### PR TITLE
Fix vmid in VM targeted parsing

### DIFF
--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -109,7 +109,7 @@ if [ ! -z "${vm_resources}" ]; then
         dv_resources+=("$dv_name")
       done
     
-      target_vm_id+=($(echo $vm_data | jq -r '.metadata.labels.vmID'))
+      target_vm_id=($(echo $vm_data | jq -r '.metadata.labels.vmID'))
       log_filter_query="$log_filter_query|$target_vm_name"
       dump_resource "virtualmachine" $target_vm_name $target_ns
 


### PR DESCRIPTION
Fixing typo in VirtualMachine CR parsing and storing "vmid" variable for
related log gathering e.g. virt-v2v conversion log in this case.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2023680