### PR TITLE
Fix build script with deprecated Centos 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-must-gather:4.9 as builder
 
 FROM registry.access.redhat.com/ubi8-minimal:latest
-RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
+RUN echo -ne "[centos-8-stream-appstream]\nname = CentOS 8 Stream (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 
 RUN microdnf -y install rsync tar gzip graphviz jq findutils
 


### PR DESCRIPTION
Forklift must-gather image requires packages not available in RH UBIs (even in non-minimal versions), so there were
Centos 8 yum repo sources. That was recently deprecated what leads to image build failures.

Replacing Centos 8 with Centos Stream to fix upstream image build.