### PR TITLE
Gather migration hooks logs

### DIFF
--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -122,6 +122,12 @@ if [ ! -z "${vm_resources}" ]; then
         dump_resource "virtualmachine" $target_vm_name $target_ns
         present_vm_resources+=("$target_vm_name")
 
+        # Gather VM hook jobs if present
+        for job_name in $(oc get jobs --no-headers -n $MIGRATION_NS --selector vmID=$vmid -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}'); do
+          dump_resource "job" $job_name $MIGRATION_NS
+          echo "${MIGRATION_NS},${job_name}" >> /tmp/jobs
+        done
+
         # Store VM in list to allow virt-launcher pod logs gathering
         echo "${target_ns},${target_vm_name},${target_vm_id}" >> /tmp/target_vms
       else

--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -123,9 +123,10 @@ if [ ! -z "${vm_resources}" ]; then
         present_vm_resources+=("$target_vm_name")
 
         # Gather VM hook jobs if present
-        for job_name in $(oc get jobs --no-headers -n $MIGRATION_NS --selector vmID=$vmid -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}'); do
+        for job_name in $(/usr/bin/oc get jobs --no-headers -n $MIGRATION_NS --selector vmID=$target_vm_id -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}'); do
           dump_resource "job" $job_name $MIGRATION_NS
-          echo "${MIGRATION_NS},${job_name}" >> /tmp/jobs
+          job_pod_name=$(/usr/bin/oc get pods --no-headers -n $MIGRATION_NS --selector job-name=$job_name -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+          echo "${MIGRATION_NS},${job_pod_name}" >> /tmp/job_pods
         done
 
         # Store VM in list to allow virt-launcher pod logs gathering

--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -111,10 +111,10 @@ if [ ! -z "${vm_resources}" ]; then
 
         # Gather VMs DataVolumes
         for dv_name in $(echo $vm_data | jq -r '.spec.template.spec.volumes[] .dataVolume.name'); do
-          dump_resource "datavolume" $dv_id $target_ns
+          dump_resource "datavolume" $dv_name $target_ns
 
           # Store DV in list to allow importer pod logs gathering
-          echo "${target_ns},${dv_id}" >> /tmp/dvs
+          echo "${target_ns},${dv_name}" >> /tmp/dvs
         done
 
         target_vm_id=($(echo $vm_data | jq -r '.metadata.labels.vmID'))

--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -108,8 +108,13 @@ if [ ! -z "${vm_resources}" ]; then
       if [ $(/usr/bin/oc get virtualmachine ${target_vm_name} -n ${target_ns} | grep ${target_vm_name} | wc -l) == "1" ]; then
         # Parse VM for related resources
         vm_data=$(/usr/bin/oc get virtualmachine ${target_vm_name} -n ${target_ns} -o json)
+
+        # Gather VMs DataVolumes
         for dv_name in $(echo $vm_data | jq -r '.spec.template.spec.volumes[] .dataVolume.name'); do
-          dv_resources+=("$dv_name")
+          dump_resource "datavolume" $dv_id $target_ns
+
+          # Store DV in list to allow importer pod logs gathering
+          echo "${target_ns},${dv_id}" >> /tmp/dvs
         done
 
         target_vm_id=($(echo $vm_data | jq -r '.metadata.labels.vmID'))
@@ -122,16 +127,6 @@ if [ ! -z "${vm_resources}" ]; then
       else
         echo "VirtualMachine ${target_vm_name} doesn't exist in ${target_ns} namespace, skipping."
       fi
-    done
-fi
-
-if [ ! -z "${dv_resources}" ]; then
-    echo "Gathering datavolumes.."
-    for dv_id in ${dv_resources[@]}; do
-      dump_resource "datavolume" $dv_id $target_ns
-
-      # Store DV in list to allow importer pod logs gathering
-      echo "${target_ns},${dv_id}" >> /tmp/dvs
     done
 fi
 

--- a/collection-scripts/targeted_logs
+++ b/collection-scripts/targeted_logs
@@ -16,7 +16,7 @@ namespaces=$1
 targeted_query="$(cat /tmp/targeted_logs_grep_query)"
 target_vms="$(touch /tmp/target_vms; cat /tmp/target_vms)"
 target_dvs="$(touch cat /tmp/dvs; cat /tmp/dvs)"
-target_jobs="$(touch cat /tmp/jobs; cat /tmp/jobs)"
+target_job_pods="$(touch cat /tmp/job_pods; cat /tmp/job_pods)"
 
 # Collect all Pod logs from namespaces where Forklift is installed
 for ns in ${namespaces[@]}; do
@@ -85,12 +85,12 @@ for nsdv in ${target_dvs[@]}; do
 done
 
 # Collect migration hook jobs logs
-for nsjob in ${target_jobs[@]}; do
-  IFS="," read ns job_name <<< $nsjob
-  object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
+for nsjobpod in ${target_job_pods[@]}; do
+  IFS="," read ns job_pod <<< $nsjobpod
+  object_collection_path="/must-gather/namespaces/${ns}/logs/${job_pod}"
   mkdir -p ${object_collection_path}
-  echo "[ns=${ns}][job=${pod}] Collecting migration hook job logs..."
-  /usr/bin/oc logs --namespace ${ns} ${job_name} &> "${object_collection_path}/current.log" &
+  echo "[ns=${ns}][job=${job_pod}] Collecting migration hook job's pod logs..."
+  /usr/bin/oc logs --namespace ${ns} ${job_pod} &> "${object_collection_path}/current.log" &
   pwait $max_parallelism
 done
 

--- a/collection-scripts/targeted_logs
+++ b/collection-scripts/targeted_logs
@@ -16,6 +16,7 @@ namespaces=$1
 targeted_query="$(cat /tmp/targeted_logs_grep_query)"
 target_vms="$(touch /tmp/target_vms; cat /tmp/target_vms)"
 target_dvs="$(touch cat /tmp/dvs; cat /tmp/dvs)"
+target_jobs="$(touch cat /tmp/jobs; cat /tmp/jobs)"
 
 # Collect all Pod logs from namespaces where Forklift is installed
 for ns in ${namespaces[@]}; do
@@ -81,6 +82,16 @@ for nsdv in ${target_dvs[@]}; do
     /usr/bin/oc logs --all-containers --namespace ${ns} ${pod} &> "${object_collection_path}/current.log" &
     pwait $max_parallelism
   fi
+done
+
+# Collect migration hook jobs logs
+for nsjob in ${target_jobs[@]}; do
+  IFS="," read ns job_name <<< $nsjob
+  object_collection_path="/must-gather/namespaces/${ns}/logs/${pod}"
+  mkdir -p ${object_collection_path}
+  echo "[ns=${ns}][job=${pod}] Collecting migration hook job logs..."
+  /usr/bin/oc logs --namespace ${ns} ${job_name} &> "${object_collection_path}/current.log" &
+  pwait $max_parallelism
 done
 
 wait


### PR DESCRIPTION
A VM migration can include pre and post migration hooks which are Jobs (k8s resources) that could contain relevant information in their log files. Adding migration hooks jobs logs to the targeted gathering.

Addresses https://github.com/konveyor/forklift-must-gather/issues/45 and fixes https://bugzilla.redhat.com/show_bug.cgi?id=2059335