### PR TITLE
Backport #52 to v2.3.2

### DIFF
--- a/collection-scripts/targeted_logs
+++ b/collection-scripts/targeted_logs
@@ -45,7 +45,7 @@ done
 for nsvm in ${target_vms[@]}; do
   IFS="," read ns vm vmid <<< $nsvm
   virtLauncherPod=$(oc get pods --no-headers -n $ns --selector kubevirt.io=virt-launcher -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | grep $vm | head -1)
-  virtV2VPod=$(oc get pods --no-headers -n $ns --selector vmID=$vmid -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | grep $vmid | head -1)
+  virtV2VPod=$(oc get pods --no-headers -n $ns --selector vmID=$vmid -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | head -1)
 
   if [[ -z $virtLauncherPod ]]; then
     echo "Virt-launcher Pod for $nsvm doesn't exist, skipping."


### PR DESCRIPTION
Virtv2v pods are named based on the plan name and VM id. If
the plan and VM id are too long, the name of the pod will be
truncated and not contain the entire plan or VM id. Targeted
log collection will fail for such a pod, as the collection
script attempts to grep for the entire VM id in the pod name.

Because the collection script already filters for pods based
on the vmID label, this additional grep for the VM id in the
pod name should be redundant. Removing it allows the pod to be
found and logs collected.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2064336