### PR TITLE
Fix collision when collecting VM CRs

### DIFF
--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -64,7 +64,7 @@ if [ ! -z $VM ]; then
   vm_resources+=("$VM")
   if [ -z "${target_ns}" ]; then
     # Try to identify a namespace for provided VM name
-    vm_list=$(oc get virtualmachines -A | grep ${VM})
+    vm_list=$(oc get virtualmachines -A | grep -w ${VM})
     if [ $(echo "$vm_list" | wc -l) == "1" ]; then
       target_ns=$(echo "$vm_list" | cut -f1 -d" ")
     else


### PR DESCRIPTION
Targeted collection fails for a VM if its name is a substring of another VM in the same namespace, due to grep returning multiple matches for the name. Add -w flag to do a whole-word comparison and avoid the collision.

```
sh-4.4$ oc get virtualmachines -A | grep auto-rhv-red-iscsi-migration-50gb-70usage-vm-2
openshift-mtv   auto-rhv-red-iscsi-migration-50gb-70usage-vm-2    5d12h   Stopped   False
openshift-mtv   auto-rhv-red-iscsi-migration-50gb-70usage-vm-20   5d11h   Stopped   False
openshift-mtv   auto-rhv-red-iscsi-migration-50gb-70usage-vm-21   5d11h   Stopped   False
openshift-mtv   auto-rhv-red-iscsi-migration-50gb-70usage-vm-22   5d11h   Stopped   False
openshift-mtv   auto-rhv-red-iscsi-migration-50gb-70usage-vm-23   5d11h   Stopped   False
openshift-mtv   auto-rhv-red-iscsi-migration-50gb-70usage-vm-24   5d11h   Stopped   False
openshift-mtv   auto-rhv-red-iscsi-migration-50gb-70usage-vm-25   5d11h   Stopped   False
openshift-mtv   auto-rhv-red-iscsi-migration-50gb-70usage-vm-26   5d11h   Stopped   False
openshift-mtv   auto-rhv-red-iscsi-migration-50gb-70usage-vm-27   5d11h   Stopped   False

sh-4.4$ oc get virtualmachines -A | grep -w auto-rhv-red-iscsi-migration-50gb-70usage-vm-2
openshift-mtv   auto-rhv-red-iscsi-migration-50gb-70usage-vm-2    5d12h   Stopped   False
```