### PR TITLE
Backport #54 to v2.3.2

### DIFF
--- a/collection-scripts/targeted_crs
+++ b/collection-scripts/targeted_crs
@@ -64,7 +64,7 @@ if [ ! -z $VM ]; then
   vm_resources+=("$VM")
   if [ -z "${target_ns}" ]; then
     # Try to identify a namespace for provided VM name
-    vm_list=$(oc get virtualmachines -A | grep ${VM})
+    vm_list=$(oc get virtualmachines -A | grep -w ${VM})
     if [ $(echo "$vm_list" | wc -l) == "1" ]; then
       target_ns=$(echo "$vm_list" | cut -f1 -d" ")
     else


### PR DESCRIPTION
Targeted collection fails for a VM if its name is a substring of another VM in the same namespace, due to grep returning multiple matches for the name. Add -w flag to do a whole-word comparison and avoid the collision.